### PR TITLE
Address issues around hasRepresentation/hasSequence in Issue 321

### DIFF
--- a/data/ext/bio/Gene.rdfa
+++ b/data/ext/bio/Gene.rdfa
@@ -100,10 +100,10 @@
       <span>Source:  <a property="dc:source" href="http://www.bioschemas.org/Gene">Gene</a></span>
   </div>
 
-  <div typeof="rdf:Property" resource="http://schema.org/hasSequence">
+  <div typeof="rdf:Property" resource="http://schema.org/hasBioPolymerSequence">
       <link property="http://schema.org/isPartOf" href="http://bio.schema.org" />
-      <span class="h" property="rdfs:label">hasSequence</span>
-      <span property="rdfs:comment">Nucleotide or amino acid sequence.</span>
+      <span class="h" property="rdfs:label">hasBioPolymerSequence</span>
+      <span property="rdfs:comment">A symbolic representation of a BioChemEnity. For example, a nucleotide sequence of a Gene or an amino acid sequence of a Protein.</span>
       <link property="rdfs:subPropertyOf" href="http://schema.org/hasRepresentation" />
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Gene">Gene</a></span>
       <!-- <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/DNA">DNA</a></span> -->

--- a/data/ext/bio/Gene.rdfa
+++ b/data/ext/bio/Gene.rdfa
@@ -12,6 +12,7 @@
   * | - https://github.com/BioSchemas/specifications/issues/277
   * | - https://github.com/BioSchemas/specifications/issues/278
   * | - https://github.com/BioSchemas/specifications/issues/317
+  * | - https://github.com/BioSchemas/specifications/issues/321
   -->
 
   <!-- Work in progress. -->
@@ -103,6 +104,7 @@
       <link property="http://schema.org/isPartOf" href="http://bio.schema.org" />
       <span class="h" property="rdfs:label">hasSequence</span>
       <span property="rdfs:comment">Nucleotide or amino acid sequence.</span>
+      <link property="rdfs:subPropertyOf" href="http://schema.org/hasRepresentation" />
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Gene">Gene</a></span>
       <!-- <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/DNA">DNA</a></span> -->
       <!-- <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/RNA">RNA</a></span> -->

--- a/data/ext/bio/MolecularEntity.rdfa
+++ b/data/ext/bio/MolecularEntity.rdfa
@@ -20,6 +20,7 @@
       <link property="http://schema.org/isPartOf" href="http://bio.schema.org" />
       <span class="h" property="rdfs:label">inChI</span>
       <span property="rdfs:comment">Non-proprietary identifier for molecular entity that can be used in printed and electronic data sources thus enabling easier linking of diverse data compilations.</span>
+      <link property="rdfs:subPropertyOf" href="http://schema.org/hasRepresentation" />
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MolecularEntity">MolecularEntity</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
       <span>Source:  <a property="dc:source" href="http://www.bioschemas.org/MolecularEntity">MolecularEntity</a></span>
@@ -29,6 +30,7 @@
       <link property="http://schema.org/isPartOf" href="http://bio.schema.org" />
       <span class="h" property="rdfs:label">inChIKey</span>
       <span property="rdfs:comment">InChIKey is a hashed version of the full InChI (using the SHA-256 algorithm).</span>
+      <link property="rdfs:subPropertyOf" href="http://schema.org/hasRepresentation" />
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MolecularEntity">MolecularEntity</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
       <span>Source:  <a property="dc:source" href="http://www.bioschemas.org/MolecularEntity">MolecularEntity</a></span>
@@ -74,6 +76,7 @@
       <link property="http://schema.org/isPartOf" href="http://bio.schema.org" />
       <span class="h" property="rdfs:label">smiles</span>
       <span property="rdfs:comment">A specification in form of a line notation for describing the structure of chemical species using short ASCII strings.</span>
+      <link property="rdfs:subPropertyOf" href="http://schema.org/hasRepresentation" />
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MolecularEntity">MolecularEntity</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
       <span>Source:  <a property="dc:source" href="http://www.bioschemas.org/MolecularEntity">MolecularEntity</a></span>

--- a/data/ext/bio/Protein.rdfa
+++ b/data/ext/bio/Protein.rdfa
@@ -4,6 +4,7 @@
   * | Project: https://bioschemas.org
   * | MailingList: https://lists.w3.org/Archives/Public/public-bioschemas/
   * | Issues:
+  * | - https://github.com/BioSchemas/specifications/issues/321
   -->
 
   <div typeof="rdfs:Class" resource="http://schema.org/Protein">


### PR DESCRIPTION
In this pull request I have renamed `hasSequence` to `hasBioPolymerSequence` and updated the definition. This makes clearer the distinction between these properties and how they would be used.

I have also declared 3 properties on `MolecularEntity` as sub-properties of `hasRepresentation`.

This is as per the discussion in https://github.com/BioSchemas/specifications/issues/321